### PR TITLE
Fix Google Calendar connection

### DIFF
--- a/src/components/settings/GoogleCalendarIntegration.tsx
+++ b/src/components/settings/GoogleCalendarIntegration.tsx
@@ -63,9 +63,9 @@ export const GoogleCalendarIntegration = () => {
 
       if (error) throw error;
 
-      if (data.authorization_url) {
+      if (data.authUrl) {
         // Open OAuth URL in new window
-        window.open(data.authorization_url, 'google-oauth', 'width=500,height=600');
+        window.open(data.authUrl, 'google-oauth', 'width=500,height=600');
         
         // Poll for completion (in a real app, you'd use window messaging)
         const pollForConnection = setInterval(async () => {


### PR DESCRIPTION
The Google Calendar connection was not initiating the OAuth flow due to an issue in the `GoogleCalendarIntegration` component. This commit fixes the `handleConnectGoogleCalendar` function to correctly trigger the OAuth popup when the "Connect Google Calendar" button is clicked, resolving the loading spinner issue and enabling users to sync their calendars.